### PR TITLE
start.sh puerto

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -32,4 +32,4 @@ cd $PROJECT_DIR
 
 # Iniciar el servidor de Django
 echo "Iniciando el servidor de Django..."
-python manage.py runserver
+python manage.py runserver 8245


### PR DESCRIPTION
# Puerto en start.sh

Cambiado el puerto en el script porque el usado por defecto en Django (8000) es demasiado común y choca con otras cosas en mi sistema.